### PR TITLE
Fixed Basic Auth

### DIFF
--- a/WebKitBrowserTest/WebBrowserTabPage.cs
+++ b/WebKitBrowserTest/WebBrowserTabPage.cs
@@ -29,13 +29,7 @@ using WebKit;
 
 namespace WebKitBrowserTest
 {
-    public class TestScriptObject
-    {
-        public void f()
-        {
-            MessageBox.Show("Hey!");
-        }
-    }
+   
 
     public partial class WebBrowserTabPage : TabPage
     {
@@ -129,6 +123,14 @@ namespace WebKitBrowserTest
         {
             browser.Stop();
             statusLabel.Text = "Stopped";
+        }
+    }
+
+    public class TestScriptObject
+    {
+        public void f()
+        {
+            MessageBox.Show("Hey!");
         }
     }
 }

--- a/WebKitCore/WebPolicyDelegate.cs
+++ b/WebKitCore/WebPolicyDelegate.cs
@@ -37,9 +37,13 @@ namespace WebKit
         public bool AllowDownloads;
         public bool AllowNewWindows;
         public bool AllowNavigation;
+        private WebKitBrowserCore wbc;
+        public bool pwdEnabled;
 
         // so that we can load and display the first page
         public bool AllowInitialNavigation;
+
+        
 
         public WebPolicyDelegate(bool AllowNavigation, bool AllowDownloads, bool AllowNewWindows)
         {
@@ -47,6 +51,11 @@ namespace WebKit
             this.AllowNavigation = AllowNavigation;
             this.AllowNewWindows = AllowNewWindows;
             AllowInitialNavigation = true;
+        }
+
+        public WebPolicyDelegate(bool AllowNavigation, bool AllowDownloads, bool AllowNewWindows, WebKitBrowserCore b) : this(AllowNavigation, AllowDownloads, AllowNewWindows)
+        {
+            wbc = b;
         }
 
         #region IWebPolicyDelegate Members
@@ -68,10 +77,22 @@ namespace WebKit
             }
         }
 
+
         public void decidePolicyForNavigationAction(WebView WebView, CFDictionaryPropertyBag actionInformation, IWebURLRequest request, webFrame frame, IWebPolicyDecisionListener listener)
         {
             if (AllowNavigation || AllowInitialNavigation)
+            {
+                //use basic authentication if username and password are supplied.
+                if (pwdEnabled && string.IsNullOrEmpty(request.valueForHTTPHeaderField("Authorization")) && wbc!=null)
+                {
+                    
+                    wbc.Navigate(request.url());
+                    listener.ignore();
+                    return;
+                }
+
                 listener.use();
+            }
             else
                 listener.ignore();
         }


### PR DESCRIPTION
Hey peterdn,

I fixed the bug I described where Basic Authentication only happens on the initial navigate call, but not on any subsequent link clicks or redirects.  The fix is kind of ugly though.  This may be best as a patch, but I haven't figured those out yet, and I figured you could best decide what to do with it.  I added some code in the WebResourceLoadDelegate to check for a username and password, and, if one was provided, but the header is not included, cancel that web request and re-call the navigate method, including the username and password. Let me know what you think.

~therealmitchconnors
