### PR TITLE
Fixed assembly reference

### DIFF
--- a/WebKitCore/WebKitCore.csproj
+++ b/WebKitCore/WebKitCore.csproj
@@ -44,7 +44,7 @@
     <Reference Include="System.Xml" />
     <Reference Include="WebKit.Interop, Version=533.0.0.0, Culture=neutral, PublicKeyToken=b967213f6d29a3be, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\bin\Debug\WebKit.Interop.dll</HintPath>
+      <HintPath>..\webkit\WebKit.Interop.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
I fixed the WebKit.Interop dll reference to not be a bin/debug folder reference. This should allow other people to pull and build right off the bat.
